### PR TITLE
feat: implement theme persistence with ThemeRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,9 +40,7 @@ android {
 }
 
 dependencies {
-
-    implementation("androidx.datastore:datastore-preferences:1.1.7")
-
+    implementation(libs.androidx.datastore.preferences)
     implementation(libs.androidx.viewmodel.compose)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/src/main/java/com/example/todoapp/MainActivity.kt
+++ b/app/src/main/java/com/example/todoapp/MainActivity.kt
@@ -3,14 +3,24 @@ package com.example.todoapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.example.todoapp.data.ThemeRepository
 import com.example.todoapp.data.TodoRepository
+import com.example.todoapp.ui.TodoScreen
+import com.example.todoapp.ui.theme.TodoAppTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            val repository = TodoRepository(context = this)
-            TodoApp(repository = repository)
+            val context = this
+            val todoRepository = TodoRepository(context)
+            val themeRepository = ThemeRepository(context)
+                TodoApp(
+                    repository = todoRepository,
+                    themeRepository = themeRepository
+                )
         }
     }
 }

--- a/app/src/main/java/com/example/todoapp/TodoApp.kt
+++ b/app/src/main/java/com/example/todoapp/TodoApp.kt
@@ -3,15 +3,25 @@ package com.example.todoapp
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.example.todoapp.data.ThemeRepository
 import com.example.todoapp.data.TodoRepository
 import com.example.todoapp.ui.TodoScreen
 import com.example.todoapp.ui.theme.TodoAppTheme
 
 @Composable
-fun TodoApp(repository: TodoRepository) {
-    TodoAppTheme {
+fun TodoApp(
+    repository: TodoRepository,
+    themeRepository: ThemeRepository,
+) {
+    val isDarkTheme by themeRepository.isDarkTheme.collectAsState(false)
+    TodoAppTheme(darkTheme = isDarkTheme) {
         Surface(color = MaterialTheme.colorScheme.background){
-            TodoScreen(repository = repository)
+            TodoScreen(
+                repository = repository,
+                themeRepository = themeRepository
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/todoapp/data/ThemeRepository.kt
+++ b/app/src/main/java/com/example/todoapp/data/ThemeRepository.kt
@@ -1,0 +1,28 @@
+package com.example.todoapp.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+val Context.themeDataStore: DataStore<Preferences> by preferencesDataStore(name = "theme_settings")
+
+class ThemeRepository(context: Context) {
+    private val dataSore = context.themeDataStore
+
+    private val KEY_THEME = booleanPreferencesKey("dark_theme")
+
+    val isDarkTheme: Flow<Boolean> = dataSore.data.map { preferences ->
+        preferences[KEY_THEME] ?: false
+    }
+
+    suspend fun setDarkTheme(enabled: Boolean){
+        dataSore.edit { preferences ->
+            preferences[KEY_THEME] = enabled
+        }
+    }
+}

--- a/app/src/main/java/com/example/todoapp/ui/TodoScreen.kt
+++ b/app/src/main/java/com/example/todoapp/ui/TodoScreen.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,21 +23,26 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.todoapp.data.ThemeRepository
+import com.example.todoapp.data.TodoRepository
 import com.example.todoapp.ui.component.TodoItemCard
 import com.example.todoapp.viewmodel.TodoViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.todoapp.data.TodoRepository
 
 @Composable
-fun TodoScreen(repository: TodoRepository) {
+fun TodoScreen(
+    repository: TodoRepository,
+    themeRepository: ThemeRepository
+) {
     val viewModel: TodoViewModel = viewModel(factory = object : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return TodoViewModel(repository) as T
+            return TodoViewModel(repository, themeRepository) as T
         }
     })
     var title by remember { mutableStateOf("") }
     val todos by viewModel.todos
+    val isDarkTheme = viewModel.isDarkTheme
 
     Column(
         modifier = Modifier
@@ -64,6 +71,17 @@ fun TodoScreen(repository: TodoRepository) {
             }
         }
         Spacer(modifier = Modifier.height(16.dp))
+
+        Row {
+            Text(
+                text = if(isDarkTheme)"Тёмная тема" else "Светлая тема",
+                modifier = Modifier.weight(1f)
+            )
+            Switch(
+                checked = isDarkTheme,
+                onCheckedChange = { viewModel.setDarkTheme(it)}
+            )
+        }
 
         LazyColumn {
             items(

--- a/app/src/main/java/com/example/todoapp/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/todoapp/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.example.todoapp.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/com/example/todoapp/viewmodel/TodoViewModel.kt
+++ b/app/src/main/java/com/example/todoapp/viewmodel/TodoViewModel.kt
@@ -1,26 +1,46 @@
 package com.example.todoapp.viewmodel
 
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.todoapp.data.ThemeRepository
 import com.example.todoapp.data.TodoRepository
 import com.example.todoapp.model.TodoItem
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
 
 class TodoViewModel(
-    private val repository: TodoRepository
+    private val repository: TodoRepository,
+    private val themeRepository: ThemeRepository
 ) : ViewModel() {
     var todos = mutableStateOf<List<TodoItem>>(emptyList())
         private set
+    private val _isDarkTheme = mutableStateOf(false)
+    val isDarkTheme: Boolean by _isDarkTheme
 
     init {
+        viewModelScope.launch {
+            themeRepository.isDarkTheme.collect { dark ->
+                _isDarkTheme.value = dark
+            }
+        }
+
         viewModelScope.launch {
             repository.todos.collect { loadedTodos ->
                 todos.value = loadedTodos
             }
         }
     }
+
+    fun setDarkTheme(enabled: Boolean) {
+        _isDarkTheme.value = enabled
+        viewModelScope.launch {
+            themeRepository.setDarkTheme(enabled)
+        }
+    }
+
     fun addTodo(title: String) {
         val newId = if (todos.value.isEmpty()) 0 else todos.value.maxOf { it.id } + 1
         val newTodo = TodoItem(id = newId, title = title, isDone = false)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,10 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.9.3"
 activityCompose = "1.10.1"
 composeBom = "2025.08.01"
+dataStore = "1.1.7"
 
 [libraries]
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "dataStore"}
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }


### PR DESCRIPTION
- Created ThemeRepository to manage dark/light theme state using DataStore
- Updated TodoViewModel to support theme state via injected ThemeRepository
- In MainActivity, subscribed to theme flow and passed value to TodoAppTheme